### PR TITLE
Staff can sign in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    bcrypt (3.1.13)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -76,6 +77,16 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    devise (4.7.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
@@ -110,6 +121,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -156,6 +168,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -200,6 +215,8 @@ GEM
       sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -213,6 +230,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Response : {articles:[{id:1,title:"title1"},{id:2,title:"title2"}]}
 ```
 
 get /articles/:id
-:id exists in db gives a 200 response with body: 
+:id exists in db gives a 200 response with body:
+
 ```
 {
   "article": {
@@ -35,7 +36,9 @@ get /articles/:id
   }
 }
 ```
+
 :id does not exist in db gives a 404 with body:
+
 ```
 {
   "message": "Article with id :id could not be found"
@@ -44,13 +47,16 @@ get /articles/:id
 
 post /articles
 with :title and :body params, gives 200 response with body:
+
 ```
 {
   "id": :id,
   "message": "Article successfully created!"
 }
 ```
+
 with :title or :body params missing, gives 400 response with body:
+
 ```
 {
   "message": "Title can't be blank"
@@ -60,5 +66,30 @@ or
 
 {
   "message": "Body can't be blank"
+}
+```
+
+### **Login**
+
+post /auth/sign_in
+
+```
+{
+    "data":
+  {"id":12,
+   "email":"mystring@mail.com",
+   "provider":"email",
+   "uid":"mystring@mail.com",
+   "allow_password_change":false,
+   "name":"User Example",
+   "image":"imageURL"}
+}
+```
+
+with wrong password or email
+
+```
+{
+    "success":false, "errors":["Invalid login credentials. Please try again."]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ get /articles/:id
 }
 ```
 
-post /articles
+post /articles **Requires authentication headers!**
+Headers need to include the standard { uid: "", client: "", access_token: "", expiry: "", token_type: "Bearer" }
 with :title and :body params, gives 200 response with body:
 
 ```
@@ -70,7 +71,7 @@ or
 ```
 
 ### **Login**
-
+All [devise_token_auth endpoints](https://devise-token-auth.gitbook.io/devise-token-auth/usage) are open, only sign in is tested for right now.
 post /auth/sign_in
 
 ```
@@ -81,8 +82,6 @@ post /auth/sign_in
    "provider":"email",
    "uid":"mystring@mail.com",
    "allow_password_change":false,
-   "name":"User Example",
-   "image":"imageURL"}
 }
 ```
 

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::ArticlesController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
+  
   def index
     article = Article.all
     render json: article, each_serializer: Article::IndexSerializer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,6 @@
 
 class User < ActiveRecord::Base
   extend Devise::Models
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,55 +1,5 @@
 # frozen_string_literal: true
 
 DeviseTokenAuth.setup do |config|
-  # By default the authorization headers will change after each request. The
-  # client is responsible for keeping track of the changing tokens. Change
-  # this to false to prevent the Authorization header from changing after
-  # each request.
-  # config.change_headers_on_each_request = true
-
-  # By default, users will need to re-authenticate after 2 weeks. This setting
-  # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
-
-  # Limiting the token_cost to just 4 in testing will increase the performance of
-  # your test suite dramatically. The possible cost value is within range from 4
-  # to 31. It is recommended to not use a value more than 10 in other environments.
   config.token_cost = Rails.env.test? ? 4 : 10
-
-  # Sets the max number of concurrent devices per user, which is 10 by default.
-  # After this limit is reached, the oldest tokens will be removed.
-  # config.max_number_of_devices = 10
-
-  # Sometimes it's necessary to make several requests to the API at the same
-  # time. In this case, each request in the batch will need to share the same
-  # auth token. This setting determines how far apart the requests can be while
-  # still using the same auth token.
-  # config.batch_request_buffer_throttle = 5.seconds
-
-  # This route will be the prefix for all oauth2 redirect callbacks. For
-  # example, using the default '/omniauth', the github oauth2 provider will
-  # redirect successful authentications to '/omniauth/github/callback'
-  # config.omniauth_prefix = "/omniauth"
-
-  # By default sending current password is not needed for the password update.
-  # Uncomment to enforce current_password param to be checked before all
-  # attribute updates. Set it to :password if you want it to be checked only if
-  # password is updated.
-  # config.check_current_password_before_update = :attributes
-
-  # By default we will use callbacks for single omniauth.
-  # It depends on fields like email, provider and uid.
-  # config.default_callbacks = true
-
-  # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
-
-  # By default, only Bearer Token authentication is implemented out of the box.
-  # If, however, you wish to integrate with legacy Devise authentication, you can
-  # do so by enabling this flag. NOTE: This feature is highly experimental!
-  # config.enable_standard_devise_support = false
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 DeviseTokenAuth.setup do |config|
+  config.change_headers_on_each_request = false
+  config.token_lifespan = 2.weeks
   config.token_cost = Rails.env.test? ? 4 : 10
+  config.batch_request_buffer_throttle = 5.seconds
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
+  mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
     resources :articles, only: %i[index show create], constraints: { format: 'json' }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     resources :articles, only: %i[index show create], constraints: { format: 'json' }
   end

--- a/db/migrate/20200522085432_devise_token_auth_create_users.rb
+++ b/db/migrate/20200522085432_devise_token_auth_create_users.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, null: false, default: 'email'
+      t.string :uid, null: false, default: ''
+
+      ## Database authenticatable
+      t.string :encrypted_password, null: false, default: ''
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, default: false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :image
+      t.string :email
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, %i[uid provider], unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/migrate/20200522085432_devise_token_auth_create_users.rb
+++ b/db/migrate/20200522085432_devise_token_auth_create_users.rb
@@ -19,8 +19,6 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
       t.datetime :confirmation_sent_at
       t.string   :unconfirmed_email
 
-      t.string :name
-      t.string :image
       t.string :email
 
       t.json :tokens

--- a/db/migrate/20200522085432_devise_token_auth_create_users.rb
+++ b/db/migrate/20200522085432_devise_token_auth_create_users.rb
@@ -3,38 +3,26 @@
 class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table(:users) do |t|
-      ## Required
       t.string :provider, null: false, default: 'email'
       t.string :uid, null: false, default: ''
 
-      ## Database authenticatable
       t.string :encrypted_password, null: false, default: ''
 
-      ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
       t.boolean  :allow_password_change, default: false
 
-      ## Rememberable
       t.datetime :remember_created_at
 
-      ## Confirmable
       t.string   :confirmation_token
       t.datetime :confirmed_at
       t.datetime :confirmation_sent_at
-      t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :unconfirmed_email
 
-      ## Lockable
-      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
-      # t.string   :unlock_token # Only if unlock strategy is :email or :both
-      # t.datetime :locked_at
-
-      ## User Info
       t.string :name
       t.string :image
       t.string :email
 
-      ## Tokens
       t.json :tokens
 
       t.timestamps
@@ -49,6 +37,5 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
     add_index :users, %i[uid provider], unique: true
     add_index :users, :reset_password_token, unique: true
     add_index :users, :confirmation_token,   unique: true
-    # add_index :users, :unlock_token,       unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
 ActiveRecord::Schema.define(version: 2020_05_22_085432) do
 
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "articles", force: :cascade do |t|
@@ -21,8 +34,6 @@ ActiveRecord::Schema.define(version: 2020_05_22_085432) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.string "name"
-    t.string "image"
     t.string "email"
     t.json "tokens"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,18 +1,5 @@
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
-
 ActiveRecord::Schema.define(version: 2020_05_22_085432) do
 
-  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "articles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_21_092257) do
+ActiveRecord::Schema.define(version: 2020_05_22_085432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,35 @@ ActiveRecord::Schema.define(version: 2020_05_21_092257) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "image"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :user do
-    name { "User Example" }
     email { "MyString@mail.com" }
     password { "MyString123" }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { "User Example" }
+    email { "MyString@mail.com" }
+    password { "MyString123" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe User, type: :model do
+  it 'should have a valid Factory' do
+    expect(create(:user)).to be_valid
+  end
+  describe 'Datatbase table' do
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :image }
+    it { is_expected.to have_db_column :tokens }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_confirmation_of :password }
+
+    context 'should not have an invalid email address' do
+      emails = ['asdf@ ds.com', '@example.com', 'test me @yahoo.com',
+                'asdf@example', 'ddd@.d. .d', 'ddd@.d']
+
+      emails.each do |email|
+        it { is_expected.not_to allow_value(email).for(:email) }
+      end
+    end
+
+    context 'should have a valid email address' do
+      emails = ['asdf@ds.com', 'hello@example.uk', 'test1234@yahoo.si',
+                'asdf@example.eu']
+
+      emails.each do |email|
+        it { is_expected.to allow_value(email).for(:email) }
+      end
+    end
+
+    describe 'Factory' do
+      it 'Should have valid factory' do
+        expect(create(:user)).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe User, type: :model do
   describe 'Datatbase table' do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }
-    it { is_expected.to have_db_column :name }
-    it { is_expected.to have_db_column :image }
     it { is_expected.to have_db_column :tokens }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe User, type: :model do
   it 'should have a valid Factory' do
     expect(create(:user)).to be_valid
   end
+  
   describe 'Datatbase table' do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }

--- a/spec/requests/api/article_create_request_spec.rb
+++ b/spec/requests/api/article_create_request_spec.rb
@@ -1,9 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Api::Articles :create', type: :request do
-  describe 'Journalist can successfully post an article' do
+  let(:user) { create(:user) }
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+
+  describe 'not logged in user cannot create an article' do
     before do
       post '/api/articles', params: { title: 'A title', body: 'The body' }
+    end
+
+    it 'has a 401 response' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'responds with error message' do
+      expect(response_json['errors']).to eq ["You need to sign in or sign up before continuing."]
+    end
+  end
+
+  describe 'Journalist can successfully post an article' do
+    before do
+      post '/api/articles', headers: headers, params: { title: 'A title', body: 'The body' }
     end
 
     it 'has a 200 response' do
@@ -22,7 +40,7 @@ RSpec.describe 'Api::Articles :create', type: :request do
   describe 'Journalist cannot post an article when' do
     describe 'title is missing' do
       before do
-        post '/api/articles', params: { body: 'The body' }
+        post '/api/articles', headers: headers, params: { body: 'The body' }
       end
 
       it 'has a 400 response' do
@@ -36,7 +54,7 @@ RSpec.describe 'Api::Articles :create', type: :request do
 
     describe 'body is missing' do
       before do
-        post '/api/articles', params: { title: 'A title' }
+        post '/api/articles', headers: headers, params: { title: 'A title' }
       end
 
       it 'has a 400 response' do

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
         'id' => user.id, 'uid' => user.email, 'email' => user.email,
         'provider' => 'email', 'allow_password_change' => false, 'name' => user.name,
         'image' => user.image
-
       }
     }
   end

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
     {
       'data' => {
         'id' => user.id, 'uid' => user.email, 'email' => user.email,
-        'provider' => 'email', 'allow_password_change' => false, 'name' => user.name
+        'provider' => 'email', 'allow_password_change' => false, 'name' => user.name,
+        'image' => user.image
 
       }
     }

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
     {
       'data' => {
         'id' => user.id, 'uid' => user.email, 'email' => user.email,
-        'provider' => 'email', 'allow_password_change' => false, 'name' => user.name,
-        'image' => user.image
+        'provider' => 'email', 'allow_password_change' => false
       }
     }
   end

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
   let(:expected_response) do
     {
       'data' => {
-        'id' => user.id, 'uid' => user.email, 'email' => user.email,
+        'id' => user.id, 'uid' => user.uid, 'email'=> user.email,
         'provider' => 'email', 'allow_password_change' => false
       }
     }
@@ -16,7 +16,7 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
     before do
       post '/api/auth/sign_in',
         params: {
-          email: user.email,
+          email: user.uid,
           password: user.password
         },
         headers: headers
@@ -35,7 +35,7 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
     before do
       post '/api/auth/sign_in',
         params: {
-          email: user.email,
+          email: user.uid,
           password: 'wrong_password'
         },
         headers: headers

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -11,14 +11,15 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
       }
     }
   end
+  
   describe 'with valid credentials' do
     before do
       post '/api/auth/sign_in',
-           params: {
-             email: user.email,
-             password: user.password
-           },
-           headers: headers
+        params: {
+          email: user.email,
+          password: user.password
+        },
+        headers: headers
     end
 
     it 'returns 200 response status' do
@@ -33,11 +34,11 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
   describe 'with invalid password' do
     before do
       post '/api/auth/sign_in',
-           params: {
-             email: user.email,
-             password: 'wrong_password'
-           },
-           headers: headers
+        params: {
+          email: user.email,
+          password: 'wrong_password'
+        },
+        headers: headers
     end
 
     it 'returns 401 response status' do
@@ -52,11 +53,11 @@ RSpec.describe 'POST /api/auth/sign_in', type: :request do
   describe 'with invalid email' do
     before do
       post '/api/auth/sign_in',
-           params: {
-             email: 'wrong@email.com',
-             password: user.password
-           },
-           headers: headers
+        params: {
+          email: 'wrong@email.com',
+          password: user.password
+        },
+        headers: headers
     end
 
     it 'returns 401 response status' do

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe 'POST /api/auth/sign_in', type: :request do
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+  let(:user) { create(:user) }
+  let(:expected_response) do
+    {
+      'data' => {
+        'id' => user.id, 'uid' => user.email, 'email' => user.email,
+        'provider' => 'email', 'allow_password_change' => false, 'name' => user.name
+
+      }
+    }
+  end
+  describe 'with valid credentials' do
+    before do
+      post '/api/auth/sign_in',
+           params: {
+             email: user.email,
+             password: user.password
+           },
+           headers: headers
+    end
+
+    it 'returns 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns the expected response' do
+      expect(response_json).to eq expected_response
+    end
+  end
+
+  describe 'with invalid password' do
+    before do
+      post '/api/auth/sign_in',
+           params: {
+             email: user.email,
+             password: 'wrong_password'
+           },
+           headers: headers
+    end
+
+    it 'returns 401 response status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'returns error message' do
+      expect(response_json['errors']).to eq ['Invalid login credentials. Please try again.']
+    end
+  end
+
+  describe 'with invalid email' do
+    before do
+      post '/api/auth/sign_in',
+           params: {
+             email: 'wrong@email.com',
+             password: user.password
+           },
+           headers: headers
+    end
+
+    it 'returns 401 response status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'returns error message' do
+      expect(response_json['errors']).to eq ['Invalid login credentials. Please try again.']
+    end
+  end
+end


### PR DESCRIPTION
[PT link](https://www.pivotaltracker.com/story/show/172936105)

Unofficial user story:
```
As an owner of the news site
In order to restrict access to creating content
I would like to require staff to sign in to the staff site in order to use it
```

## Feature
* Staff can sign in

Staff will receive their account through the admin who for now creates it in the database console.

## This PR contains:
### User model, through Devise
* Email
* Encrypted password

### Endpoint for signing in
* `post` to `/auth/sign_in`, see README for response

## Gems added:
* Devise Token Auth