### PR TITLE
CHORES: API change published at to be when article was published, not created, API update articlescontroller to check if article is published or not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ created_at is based on db created_at
 
 put /admin/articles/:id requires params: activity=="PUBLISH" and accepts :category and :premium.
 If :category is not a valid category or :premium not a boolean, an error will be returned.
-````
+```
 Success:
 { message: "Article successfully published!"}, 200
 No auth headers:

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -16,6 +16,7 @@ class Api::Admin::ArticlesController < ApplicationController
         article.premium = params[:premium] || article.premium
         article.category = params[:category] || article.category
         article.published = true
+        article.published_at = Time.now
         article.save
         render json: { message: 'Article successfully published!'}
       rescue => error

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -4,12 +4,13 @@ class Api::ArticlesController < ApplicationController
   before_action :authenticate_user!, only: [:create]
 
   def index
-    article = Article.all
+    article = Article.where(published: true)
     render json: article, each_serializer: Article::IndexSerializer
   end
 
   def show
     article = Article.find(params[:id])
+    raise StandardError unless article.published
     render json: article, serializer: Article::ShowSerializer
   rescue StandardError
     render json: { message: "Article with id #{params[:id]} could not be found." }, status: :not_found

--- a/app/serializers/article/index_serializer.rb
+++ b/app/serializers/article/index_serializer.rb
@@ -5,7 +5,7 @@ class Article::IndexSerializer < ActiveModel::Serializer
   attributes :id, :title, :category, :published_at, :image
 
   def published_at
-    object.created_at.strftime('%F %R')
+    object.published_at.strftime('%F %R')
   end
 
   def image

--- a/app/serializers/article/show_serializer.rb
+++ b/app/serializers/article/show_serializer.rb
@@ -5,7 +5,7 @@ class Article::ShowSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :published_at, :premium, :image
 
   def published_at
-    object.created_at.strftime('%F %R')
+    object.published_at.strftime('%F %R')
   end
 
   def body
@@ -20,5 +20,5 @@ class Article::ShowSerializer < ActiveModel::Serializer
     else
       object.image.service_url(expires_in: 1.hour, disposition: 'inline')
     end
-end
+  end
 end

--- a/db/migrate/20200531181519_add_published_at_to_article.rb
+++ b/db/migrate/20200531181519_add_published_at_to_article.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_27_180907) do
+ActiveRecord::Schema.define(version: 2020_05_31_181519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_05_27_180907) do
     t.integer "category", default: 0
     t.boolean "premium", default: false
     t.boolean "published", default: false
+    t.datetime "published_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/requests/api/articles_index_request_spec.rb
+++ b/spec/requests/api/articles_index_request_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe 'Api::Articles :index', type: :request do
   let!(:article) { 3.times { create(:article) } }
+  let!(:article) { 5.times { create(:article, published: true, published_at: Time.now) } }
 
   describe 'GET /api/articles' do
     before do
@@ -12,8 +13,8 @@ RSpec.describe 'Api::Articles :index', type: :request do
       expect(response).to have_http_status 200
     end
 
-    it 'has returns all articles' do
-      expect(response_json['articles'].length).to eq 3
+    it 'returns all published articles' do
+      expect(response_json['articles'].length).to eq 5
     end
 
     describe 'response has keys' do
@@ -25,7 +26,7 @@ RSpec.describe 'Api::Articles :index', type: :request do
         expect(response_json['articles'][0]).to have_key 'category'
       end
 
-      it ':created_at' do
+      it ':published_at' do
         expect(response_json['articles'][0]).to have_key 'published_at'
       end
     end

--- a/spec/requests/api/articles_show_request_spec.rb
+++ b/spec/requests/api/articles_show_request_spec.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Api::Articles :show', type: :request do
-  let!(:article) { create(:article) }
+  let!(:article) { create(:article, published: true, published_at: Time.now) }
   let(:user) { create(:user) }
   let(:credentials) { user.create_new_auth_token }
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
-  let!(:premium_article) { create(:article, premium: true) }
+  let!(:premium_article) { create(:article, published: true, published_at: Time.now, premium: true) }
 
   describe 'GET /api/articles/:id' do
     before do
-      article = Article.first
       get "/api/articles/#{article.id}"
     end
 


### PR DESCRIPTION
[PT 1](https://www.pivotaltracker.com/story/show/173043711)
- Adding :published_at to article
- It is set to Time.now when using "PUBLISH" activity
- It is returned looking just as before

[PT 2](https://www.pivotaltracker.com/story/show/173043725)
- Non-admin article controller actions only gets published articles
- It will raise standarderror if not published, looking exactly like if it did not exist on the frontend