### PR TITLE
API geolocalisation stored in articles, replacing PR#21

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ get /articles/:id
 
 post /articles **Requires authentication headers!**
 Headers need to include the standard { uid: "", client: "", access_token: "", expiry: "", token_type: "Bearer" }
-with :title, and :body params (:category is available to set, or will default to "other"), gives 200 response with body:
-
+with :title, :body, :image params (:category is available to set, or will default to "other"), gives 200 response with body:
 ```
 {
   "id": :id,
   "message": "Article successfully created!"
 }
 ```
+To set location you need 'location': 'Sweden', and if you have that you may choose international true/false.
+If location is omitted international will default to true.
 
 with :title,or :body params missing, gives 400 response with body:
 
@@ -92,6 +93,13 @@ or
 
 {
   "message": "Image can't be blank"
+}
+
+or, with when trying to be set to an invalid location
+
+{ 
+  "message": ":location, not a valid location", 
+  "errors": ['Should have a valid location'] 
 }
 ```
 

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -3,6 +3,7 @@
 class Api::Admin::ArticlesController < ApplicationController
   before_action :authenticate_user!
   before_action :editor?
+  before_action :location?
   rescue_from ActiveRecord::RecordNotFound, with: :render_active_record_error
 
   def index
@@ -31,8 +32,7 @@ class Api::Admin::ArticlesController < ApplicationController
         article.save
         render json: { message: 'Article successfully published!' }
       rescue StandardError => e
-        er=JSON.parse(e.message)
-        render json: { message: 'Article not published: ' + er }, status: 422
+        render json: { message: 'Article not published: ' + e.message }, status: 422
       end
     end
   end
@@ -42,6 +42,12 @@ class Api::Admin::ArticlesController < ApplicationController
   def editor?
     unless current_user.role == 'editor'
       render json: { message: 'You are not authorized', errors: ['You are not authorized'] }, status: 401
+    end
+  end
+
+  def location?
+    unless params[:location] == 'Sweden'
+      render json: { message: "#{params[:location]}, not a valid location", errors: ['Should have a valid location'] }, status: 422
     end
   end
 

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -46,7 +46,7 @@ class Api::Admin::ArticlesController < ApplicationController
   end
 
   def location?
-    unless params[:location] == 'Sweden'
+    unless params[:location] == 'Sweden' || params[:location] == 'International'
       render json: { message: "#{params[:location]}, not a valid location", errors: ['Should have a valid location'] }, status: 422
     end
   end

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -31,7 +31,8 @@ class Api::Admin::ArticlesController < ApplicationController
         article.save
         render json: { message: 'Article successfully published!' }
       rescue StandardError => e
-        render json: { message: 'Article not published: ' + e.message }, status: 422
+        er=JSON.parse(e.message)
+        render json: { message: 'Article not published: ' + er }, status: 422
       end
     end
   end

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -25,6 +25,7 @@ class Api::Admin::ArticlesController < ApplicationController
         article = Article.find(params[:id])
         article.premium = params[:premium] || article.premium
         article.category = params[:category] || article.category
+        article.location = params[:location] || article.location
         article.published = true
         article.published_at = Time.now
         article.save

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -3,7 +3,7 @@
 class Api::Admin::ArticlesController < ApplicationController
   before_action :authenticate_user!
   before_action :editor?
-  before_action :location?
+  before_action :valid_location?, only: [:update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_active_record_error
 
   def index
@@ -26,7 +26,8 @@ class Api::Admin::ArticlesController < ApplicationController
         article = Article.find(params[:id])
         article.premium = params[:premium] || article.premium
         article.category = params[:category] || article.category
-        article.location = params[:location] || article.location
+        article.location = params[:location]
+        article.international = article.location ? params[:international] : true
         article.published = true
         article.published_at = Time.now
         article.save
@@ -45,8 +46,8 @@ class Api::Admin::ArticlesController < ApplicationController
     end
   end
 
-  def location?
-    unless params[:location] == 'Sweden' || params[:location] == 'International'
+  def valid_location?
+    unless params[:location] == nil || params[:location] == 'Sweden'
       render json: { message: "#{params[:location]}, not a valid location", errors: ['Should have a valid location'] }, status: 422
     end
   end

--- a/app/controllers/api/admin/articles_controller.rb
+++ b/app/controllers/api/admin/articles_controller.rb
@@ -47,8 +47,8 @@ class Api::Admin::ArticlesController < ApplicationController
   end
 
   def valid_location?
-    unless params[:location] == nil || params[:location] == 'Sweden'
-      render json: { message: "#{params[:location]}, not a valid location", errors: ['Should have a valid location'] }, status: 422
+    unless params[:location].nil? || params[:location] == 'Sweden'
+      render json: { message: "'#{params[:location]}' is not a valid location" }, status: 422
     end
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,4 +4,12 @@ class Article < ApplicationRecord
   has_one_attached :image
   validates_presence_of :title, :body, :category, :location
   enum category: %i[other sport local politics economy world entertainment]
+  validate :locations, on: :update
+
+  def locations 
+    if location != "Sweden"
+      errors.add(:message, "Should have a valid location") 
+    end
+  end
+
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,15 +4,5 @@ class Article < ApplicationRecord
   has_one_attached :image
   validates_presence_of :title, :body, :category, :location
   enum category: %i[other sport local politics economy world entertainment]
-  # validates :location, presence: { accept: 'Sweden', message: "Should have a valid location" }
-  # validate :locations, on: :update
-
-  # def locations 
-  #   if location != "Sweden"
-  #     errors.add(:location, "Should have a valid location")
-  #     # binding.pry
-  #     # errors.add(:message, "Should have a valid location")
-  #   end
-  # end
 end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,12 +4,15 @@ class Article < ApplicationRecord
   has_one_attached :image
   validates_presence_of :title, :body, :category, :location
   enum category: %i[other sport local politics economy world entertainment]
-  validate :locations, on: :update
+  # validates :location, presence: { accept: 'Sweden', message: "Should have a valid location" }
+  # validate :locations, on: :update
 
-  def locations 
-    if location != "Sweden"
-      errors.add(:message, "Should have a valid location") 
-    end
-  end
-
+  # def locations 
+  #   if location != "Sweden"
+  #     errors.add(:location, "Should have a valid location")
+  #     # binding.pry
+  #     # errors.add(:message, "Should have a valid location")
+  #   end
+  # end
 end
+

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,7 +2,7 @@
 
 class Article < ApplicationRecord
   has_one_attached :image
-  validates_presence_of :title, :body, :category, :location
+  validates_presence_of :title, :body, :category
   enum category: %i[other sport local politics economy world entertainment]
 end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,6 +2,6 @@
 
 class Article < ApplicationRecord
   has_one_attached :image
-  validates_presence_of :title, :body, :category
+  validates_presence_of :title, :body, :category, :location
   enum category: %i[other sport local politics economy world entertainment]
 end

--- a/app/serializers/article/index_serializer.rb
+++ b/app/serializers/article/index_serializer.rb
@@ -2,7 +2,7 @@
 
 class Article::IndexSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
-  attributes :id, :title, :category, :published_at, :image
+  attributes :id, :title, :category, :published_at, :image, :location,
 
   def published_at
     object.published_at.strftime('%F %R')

--- a/app/serializers/article/index_serializer.rb
+++ b/app/serializers/article/index_serializer.rb
@@ -2,7 +2,7 @@
 
 class Article::IndexSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
-  attributes :id, :title, :category, :published_at, :image, :location,
+  attributes :id, :title, :category, :published_at, :image, :location, :international
 
   def published_at
     object.published_at.strftime('%F %R')

--- a/db/migrate/20200601190552_add_location_to_articles.rb
+++ b/db/migrate/20200601190552_add_location_to_articles.rb
@@ -1,0 +1,5 @@
+class AddLocationToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :location, :string
+  end
+end

--- a/db/migrate/20200602141416_add_international_to_article.rb
+++ b/db/migrate/20200602141416_add_international_to_article.rb
@@ -1,0 +1,5 @@
+class AddInternationalToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :international, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_190552) do
+ActiveRecord::Schema.define(version: 2020_06_02_141416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_190552) do
     t.boolean "published", default: false
     t.datetime "published_at"
     t.string "location"
+    t.boolean "international", default: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -70,7 +71,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_190552) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "role", default: 0
-    t.boolean "subscriber", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_31_181519) do
+ActiveRecord::Schema.define(version: 2020_06_01_190552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_05_31_181519) do
     t.boolean "premium", default: false
     t.boolean "published", default: false
     t.datetime "published_at"
+    t.string "location"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_190552) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "role", default: 0
+    t.boolean "subscriber", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,12 +2,16 @@
   file = URI.open('https://picsum.photos/800/400')
   categories = ["other", "sport", "local", "politics", "economy", "world", "entertainment"]
   premium = [true, false, false, false]
+  locations = ['Sweden', nil]
+  location = locations.sample
   article = Article.new(
     title: Faker::Company.bs.capitalize, 
     body: Faker::Lorem.paragraph(sentence_count: 70), 
     category: categories.sample, premium: premium.sample, 
     published: true, 
     published_at: Time.now
+    location: location
+    international: location ? [true,false].sample : true
   )
   article.image.attach(io: file, filename: 'image.jpg')
   article.save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,8 @@
     body: Faker::Lorem.paragraph(sentence_count: 70), 
     category: categories.sample, premium: premium.sample, 
     published: true, 
-    published_at: Time.now
-    location: location
+    published_at: Time.now,
+    location: location,
     international: location ? [true,false].sample : true
   )
   article.image.attach(io: file, filename: 'image.jpg')

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     title { 'this is title' }
     body { 'this is body, lorem ipsum.' * 20 }
     category { 'sport' }
+    location {'Sweden'}
     trait :with_image do
       image { fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'test.jpg'), 'image/jpg') }
     end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     title { 'this is title' }
     body { 'this is body, lorem ipsum.' * 20 }
     category { 'sport' }
-    location {'Sweden'}
+    location {''}
     trait :with_image do
       image { fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'test.jpg'), 'image/jpg') }
     end

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe 'Api::Admin::Articles :update', type: :request do 
+  let(:editor) { create(:user, role: 'editor') }
+  let(:article) {create(:article)}
+  let(:editors_credentials) { editor.create_new_auth_token }
+  let(:editors_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(editors_credentials) }
+
+  let(:journalist) { create(:user, email: "asd@asd.com", role: 'journalist') }
+  let(:journalist_credentials) { journalist.create_new_auth_token }
+  let(:journalist_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(journalist_credentials) }
+
+  describe 'editor successfully add location option' do 
+    before do 
+    put "api/admin/articles/#{article.id}",
+    headers: editors_headers,
+    params: {activity: "PUBLISH", location: "Sweden"}
+    article.reload()
+  end
+
+   it 'gives a success message' do 
+   expect(response_json['message']).to eq "Article successfully published!"
+   end
+
+    it'has set location to Sweden' do 
+    expect(article.location).to eq 'Sweden'
+    end
+
+    it 'gives success status' do
+      expect(response).to have_http_status 200
+    end
+  end
+
+    describe 'editor unsuccessfully set location'do 
+      before do
+        put "/api/admin/articles/#{article.id}", 
+        headers: editors_headers,
+        params: {activity: "PUBLISH", location: ""}
+        article.reload()
+      end
+    
+    it 'gives an error code' do
+    expect(response).to have_http_status 422
+    end
+
+    it 'gives an error message' do
+    expect(response_json['message']).to eq "Article not published: Should have a valid location"
+
+    end
+  end
+end 

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
 
   describe 'editor successfully add location option' do 
     before do 
-    put "api/admin/articles/#{article.id}",
+      put "/api/admin/articles/#{article.id}",
     headers: editors_headers,
-    params: {activity: "PUBLISH", location: "Sweden"}
+    params: {activity: "PUBLISH",premium: true , category: 'economy', location: "Sweden"}
     article.reload()
   end
 

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
   end
 
     describe 'editor unsuccessfully set location'do 
-    let(:article) {create(:article, location: 'France')}
+    let(:article) {create(:article, location: 'elsewhere')}
       before do
         put "/api/admin/articles/#{article.id}", 
         headers: editors_headers,
-        params: {activity: "PUBLISH", location: "France"}
+        params: {activity: "PUBLISH", location: "elsewhere"}
         article.reload()
       end
     
@@ -43,7 +43,7 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
     end
 
     it 'gives an error message' do
-    expect(response_json['message']).to eq "France, not a valid location"
+    expect(response_json['message']).to eq "elsewhere, not a valid location"
 
     end
   end

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
     end
 
     it 'gives an error message' do
-      expect(response_json['message']).to eq 'elsewhere, not a valid location'
+      expect(response_json['message']).to eq "'elsewhere' is not a valid location"
     end
   end
 end

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Api::Admin::Articles :update', type: :request do 
   let(:editor) { create(:user, role: 'editor') }
-  let(:article) {create(:article)}
+  let(:article) {create(:article, location: 'Sweden')}
   let(:editors_credentials) { editor.create_new_auth_token }
   let(:editors_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(editors_credentials) }
 
@@ -30,10 +30,11 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
   end
 
     describe 'editor unsuccessfully set location'do 
+    let(:article) {create(:article, location: 'France')}
       before do
         put "/api/admin/articles/#{article.id}", 
         headers: editors_headers,
-        params: {activity: "PUBLISH", location: ""}
+        params: {activity: "PUBLISH", location: "France"}
         article.reload()
       end
     

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -11,25 +11,47 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
   describe 'editor successfully add location option' do 
     before do 
       put "/api/admin/articles/#{article.id}",
-    headers: editors_headers,
-    params: {activity: "PUBLISH",premium: true , category: 'economy', location: "Sweden"}
-    article.reload()
-  end
+        headers: editors_headers,
+        params: {activity: "PUBLISH",premium: true , category: 'economy', location: "Sweden", international: false}
+      article.reload()
+    end
 
-   it 'gives a success message' do 
-   expect(response_json['message']).to eq "Article successfully published!"
-   end
+    it 'gives a success message' do 
+      expect(response_json['message']).to eq "Article successfully published!"
+    end
 
-    it'has set location to Sweden' do 
-    expect(article.location).to eq 'Sweden'
+    it 'has set location to Sweden' do 
+      expect(article.location).to eq 'Sweden'
     end
 
     it 'gives success status' do
       expect(response).to have_http_status 200
     end
+
+    it 'has set international to false' do
+      expect(article.international).to eq false
+    end
   end
 
-    describe 'editor unsuccessfully set location'do 
+  describe 'editor publishes without location'do 
+    let(:article) {create(:article)}
+      before do
+        put "/api/admin/articles/#{article.id}", 
+        headers: editors_headers,
+        params: {activity: "PUBLISH"}
+        article.reload()
+      end
+    
+    it 'gives an ok response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'sets :international to true' do
+      expect(article.international).to eq true
+    end
+  end
+
+  describe 'editor tries to set invalid location'do 
     let(:article) {create(:article, location: 'elsewhere')}
       before do
         put "/api/admin/articles/#{article.id}", 
@@ -39,12 +61,11 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
       end
     
     it 'gives an error code' do
-    expect(response).to have_http_status 422
+      expect(response).to have_http_status 422
     end
 
     it 'gives an error message' do
-    expect(response_json['message']).to eq "elsewhere, not a valid location"
-
+      expect(response_json['message']).to eq "elsewhere, not a valid location"
     end
   end
 end 

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
     end
 
     it 'gives an error message' do
-    expect(response_json['message']).to eq "Article not published: Should have a valid location"
+    expect(response_json['message']).to eq "France, not a valid location"
 
     end
   end

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
 
   describe 'editor publishes without location'do 
     let(:article) {create(:article)}
-      before do
-        put "/api/admin/articles/#{article.id}", 
-        headers: editors_headers,
-        params: {activity: "PUBLISH"}
-        article.reload()
-      end
+    before do
+      put "/api/admin/articles/#{article.id}", 
+      headers: editors_headers,
+      params: {activity: "PUBLISH"}
+      article.reload()
+    end
     
     it 'gives an ok response' do
       expect(response).to have_http_status 200

--- a/spec/requests/api/admin/editor_can_add_location_spec.rb
+++ b/spec/requests/api/admin/editor_can_add_location_spec.rb
@@ -1,26 +1,24 @@
-RSpec.describe 'Api::Admin::Articles :update', type: :request do 
+# frozen_string_literal: true
+
+RSpec.describe 'Api::Admin::Articles :update', type: :request do
   let(:editor) { create(:user, role: 'editor') }
-  let(:article) {create(:article, location: 'Sweden')}
+  let(:article) { create(:article, location: 'Sweden') }
   let(:editors_credentials) { editor.create_new_auth_token }
   let(:editors_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(editors_credentials) }
 
-  let(:journalist) { create(:user, email: "asd@asd.com", role: 'journalist') }
-  let(:journalist_credentials) { journalist.create_new_auth_token }
-  let(:journalist_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(journalist_credentials) }
-
-  describe 'editor successfully add location option' do 
-    before do 
+  describe 'editor successfully add location option' do
+    before do
       put "/api/admin/articles/#{article.id}",
-        headers: editors_headers,
-        params: {activity: "PUBLISH",premium: true , category: 'economy', location: "Sweden", international: false}
-      article.reload()
+          headers: editors_headers,
+          params: { activity: 'PUBLISH', premium: true, category: 'economy', location: 'Sweden', international: false }
+      article.reload
     end
 
-    it 'gives a success message' do 
-      expect(response_json['message']).to eq "Article successfully published!"
+    it 'gives a success message' do
+      expect(response_json['message']).to eq 'Article successfully published!'
     end
 
-    it 'has set location to Sweden' do 
+    it 'has set location to Sweden' do
       expect(article.location).to eq 'Sweden'
     end
 
@@ -33,15 +31,15 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
     end
   end
 
-  describe 'editor publishes without location'do 
-    let(:article) {create(:article)}
+  describe 'editor publishes without location' do
+    let(:article) { create(:article) }
     before do
-      put "/api/admin/articles/#{article.id}", 
-      headers: editors_headers,
-      params: {activity: "PUBLISH"}
-      article.reload()
+      put "/api/admin/articles/#{article.id}",
+          headers: editors_headers,
+          params: { activity: 'PUBLISH' }
+      article.reload
     end
-    
+
     it 'gives an ok response' do
       expect(response).to have_http_status 200
     end
@@ -51,21 +49,21 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
     end
   end
 
-  describe 'editor tries to set invalid location'do 
-    let(:article) {create(:article, location: 'elsewhere')}
-      before do
-        put "/api/admin/articles/#{article.id}", 
-        headers: editors_headers,
-        params: {activity: "PUBLISH", location: "elsewhere"}
-        article.reload()
-      end
-    
+  describe 'editor tries to set invalid location' do
+    let(:article) { create(:article, location: 'elsewhere') }
+    before do
+      put "/api/admin/articles/#{article.id}",
+          headers: editors_headers,
+          params: { activity: 'PUBLISH', location: 'elsewhere' }
+      article.reload
+    end
+
     it 'gives an error code' do
       expect(response).to have_http_status 422
     end
 
     it 'gives an error message' do
-      expect(response_json['message']).to eq "elsewhere, not a valid location"
+      expect(response_json['message']).to eq 'elsewhere, not a valid location'
     end
   end
-end 
+end

--- a/spec/requests/api/admin/editor_can_publish_article_spec.rb
+++ b/spec/requests/api/admin/editor_can_publish_article_spec.rb
@@ -125,7 +125,4 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
       expect(response_json['errors'][0]).to eq "You need to sign in or sign up before continuing."
     end
   end
-
-  describe 'editors can select local news' do
-
 end

--- a/spec/requests/api/admin/editor_can_publish_article_spec.rb
+++ b/spec/requests/api/admin/editor_can_publish_article_spec.rb
@@ -125,4 +125,7 @@ RSpec.describe 'Api::Admin::Articles :update', type: :request do
       expect(response_json['errors'][0]).to eq "You need to sign in or sign up before continuing."
     end
   end
+
+  describe 'editors can select local news' do
+
 end

--- a/spec/requests/api/articles_index_request_spec.rb
+++ b/spec/requests/api/articles_index_request_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe 'Api::Articles :index', type: :request do
       it ':published_at' do
         expect(response_json['articles'][0]).to have_key 'published_at'
       end
+
+      it ':location' do
+        expect(response_json['articles'][0]).to have_key 'location'
+      end
+
+      it ':international' do
+        expect(response_json['articles'][0]).to have_key 'international'
+      end
     end
   end
 end


### PR DESCRIPTION
[PT LINK](https://www.pivotaltracker.com/story/show/173109448)
- Adds `:location` and `:international` to articles
- Adds those to articles index serializer
- Adds setting logic when creating articles (if not location then international)
- Update seedfile