### PR TITLE
change page to parse strings better

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -59,8 +59,9 @@ class Api::ArticlesController < ApplicationController
   end
 
   def find_articles(main_params, opt_params = {})
-    @page = params[:page] || 1
-    offset = (@page.to_i - 1) * 24
+    page = params[:page] || 1
+    @page = page.to_i
+    offset = (@page - 1) * 24
 
     Article
       .where(**main_params, location: params[:location], published: true)


### PR DESCRIPTION
[PT API converts empty page argument to page 0 and fails](https://www.pivotaltracker.com/story/show/173213135)

Fix so that it is less sensitive to empty page argument.